### PR TITLE
Raise ValueError when link is missing rel parameter

### DIFF
--- a/httplink/__init__.py
+++ b/httplink/__init__.py
@@ -54,8 +54,10 @@ class Link:
         # Populate rel.
         try:
             self.rel = {rel.lower() for rel in self["rel"].split()}
-        except KeyError:
-            self.rel = set()
+        except KeyError as e:
+            raise ValueError(
+                "The rel parameter MUST be present per the specification (see: https://tools.ietf.org/html/rfc8288#section-3.3)."
+            ) from e
 
     def __getitem__(self, key: str) -> str:
         return self._attributes[key.lower()]

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -23,16 +23,21 @@ def test_parse() -> None:
     """
     Test parse_link_header function.
     """
-    with pytest.raises(ValueError, match="Bad link"):
-        parse_link_header("""</> </>""")
+    with pytest.raises(ValueError, match="rel parameter MUST be present"):
+        parse_link_header("""</>""")
+
+    trailing_elements_examples = [
+        """</>; rel="previous"; rev= """,
+        """</>; rel="previous" </>; rel="first" """,
+        """</>; rel="previous";, </>; rel="first" """,
+    ]
+    for example in trailing_elements_examples:
+        with pytest.raises(ValueError, match="Bad link"):
+            parse_link_header(example)
 
     assert not parse_link_header("")
     assert not parse_link_header(",")
     assert not parse_link_header(" ,, ,,, ,, ")
-
-    result = parse_link_header("""</>""")
-    assert not result.links[0]
-    assert result.links[0].rel == set()
 
     result = parse_link_header(
         '''<http://example.com/TheBook/chapter2>; rel="previous"; title="previous chapter"'''


### PR DESCRIPTION
Per [the specification](https://tools.ietf.org/html/rfc8288#section-3.3), "the rel parameter **MUST** be present...". This changelist fixes the behavior of the `parse_link_header()` function so that it raises a `ValueError` if the rel parameter is missing.